### PR TITLE
Sdk2

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ You can ask Homey a couple of questions regarding your alarm panel(s), e.g.
 Please enter bugs or feature request on [GitHub](https://github.com/nlrb/com.visonic.powermax/issues "GitHub"). For other things you can reach out to "homey.powermax _at_ gmail.com".
 
 ### Version history
+* 2.0.1 pull request Added icons to panel (RHA)
 * 2.0.0 Rewritten application to Homey SDK v2
 * 1.4.0 Add option to arm instant (device setting for UI, additional option in flows), add sensor bypass in flows
 * 1.3.0 Event log can now be retrieved under app settings, wired sensors added

--- a/app.json
+++ b/app.json
@@ -37,7 +37,8 @@
 				"nl": "Status"
 			},
 			"getable": true,
-			"setable": false
+			"setable": false,
+      "icon": "./drivers/powermax/assets/state.svg"
 		},
 		"ready": {
 			"type": "boolean",
@@ -46,7 +47,8 @@
 				"nl": "Klaar"
 			},
 			"getable": true,
-			"setable": false
+			"setable": false,
+      "icon": "./drivers/powermax/assets/ready.svg"
 		},
 		"trouble": {
 			"type": "boolean",
@@ -55,7 +57,8 @@
 				"nl": "Paneelfout"
 			},
 			"getable": true,
-			"setable": false
+			"setable": false,
+      "icon": "./drivers/powermax/assets/trouble.svg"
 		},
 		"alarm": {
 			"type": "boolean",
@@ -63,7 +66,8 @@
 				"en": "Alarm"
 			},
 			"getable": true,
-			"setable": false
+			"setable": false,
+      "icon": "./drivers/powermax/assets/alarm.svg"
 		},
 		"memory": {
 			"type": "boolean",
@@ -72,7 +76,8 @@
 				"nl": "Alarm in geheugen"
 			},
 			"getable": true,
-			"setable": false
+			"setable": false,
+      "icon": "./drivers/powermax/assets/memory.svg"
 		},
 		"dim_oneway": {
 			"type": "enum",

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.visonic.powermax",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "compatibility": ">=1.5.0",
   "sdk": 2,
   "name": {


### PR DESCRIPTION
When I open the Powermax panel in the app, the icons for panel trouble, alarm in memory ect, where missing.
In v2.0.1 I have added them again. 